### PR TITLE
fix(package): add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {
+        "types": "./types/index.d.ts",
         "import": "./build/es/index.js",
         "require": "./build/cjs/index.js"
     },


### PR DESCRIPTION
This is needed for some bundlers to properly be able to reference the types. Eg. when `moduleResolution: 'bundler'` in `tsconfig`. 


